### PR TITLE
Org hooks

### DIFF
--- a/app/commands/process_webhook_event.rb
+++ b/app/commands/process_webhook_event.rb
@@ -4,6 +4,8 @@ class ProcessWebhookEvent < PowerTypes::Command.new(request: nil, event: nil)
       PullRequestService.new(payload: @request).process
     elsif @event == 'pull_request_review'
       PullRequestReviewService.new(payload: @request).process
+    elsif @event == 'repository'
+      RepositoryService.new(payload: @request).process
     end
   end
 end

--- a/app/models/hook.rb
+++ b/app/models/hook.rb
@@ -1,28 +1,30 @@
 class Hook < ApplicationRecord
   include PowerTypes::Observable
 
-  belongs_to :repository
+  belongs_to :resource, polymorphic: true
   validates :gh_id, presence: true
-  validates :repository_id, presence: true
+  validates :resource_id, presence: true
+  validates :resource_type, presence: true
 end
 
 # == Schema Information
 #
 # Table name: hooks
 #
-#  id              :integer          not null, primary key
-#  repo_type       :string
-#  gh_id           :integer
-#  name            :string
-#  active          :boolean
-#  ping_url        :string
-#  test_url        :string
-#  repository_id   :integer
-#  repositories_id :integer
-#  created_at      :datetime         not null
-#  updated_at      :datetime         not null
+#  id            :integer          not null, primary key
+#  hook_type     :string
+#  gh_id         :integer
+#  name          :string
+#  active        :boolean
+#  ping_url      :string
+#  test_url      :string
+#  repository_id :integer
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  resource_type :string
+#  resource_id   :integer
 #
 # Indexes
 #
-#  index_hooks_on_repositories_id  (repositories_id)
+#  index_hooks_on_resource_type_and_resource_id  (resource_type,resource_id)
 #

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -3,6 +3,7 @@ class Organization < ApplicationRecord
 
   belongs_to :owner, class_name: "AdminUser"
   has_many :repositories
+  has_many :hooks, as: :resource
 
   validates :gh_id, presence: true
   validates :login, presence: true

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -6,6 +6,8 @@ class Repository < ApplicationRecord
   has_many :hooks, as: :resource
   validates :gh_id, presence: true
   validates :full_name, presence: true
+
+  delegate :owner, to: :organization, allow_nil: true
 end
 
 # == Schema Information

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -3,7 +3,7 @@ class Repository < ApplicationRecord
   include PowerTypes::Observable
   belongs_to :organization
   has_many :pull_requests
-  has_many :hooks
+  has_many :hooks, as: :resource
   validates :gh_id, presence: true
   validates :full_name, presence: true
 end

--- a/app/observers/organization_observer.rb
+++ b/app/observers/organization_observer.rb
@@ -3,7 +3,10 @@ class OrganizationObserver < PowerTypes::Observer
 
   def create_organization_repositories
     if object.tracked
+      HookService.new.subscribe(object)
       GithubWorker.perform_async("FETCH_ORG_REPOS", organization_id: object.id)
+    elsif !object.id_changed?
+      HookService.new.unsubscribe(object)
     end
   end
 end

--- a/app/services/repository_service.rb
+++ b/app/services/repository_service.rb
@@ -1,0 +1,39 @@
+class RepositoryService < PowerTypes::Service.new(:payload)
+  def process
+    case @payload[:action]
+    when 'created'
+      create_repository
+    when 'deleted'
+      delete_repository
+    end
+  end
+
+  def create_repository
+    repo
+  end
+
+  def delete_repository
+    repo&.destroy
+  end
+
+  def repo_params
+    {
+      gh_id: @payload[:repository][:id],
+      name: @payload[:repository][:name],
+      full_name: @payload[:repository][:full_name],
+      tracked: false,
+      url: @payload[:repository][:url],
+      html_url: @payload[:repository][:html_url],
+      organization: organization
+    }
+  end
+
+  def repo
+    @repo ||= Repository.create_with(repo_params)
+                        .find_or_create_by(gh_id: repo_params[:gh_id])
+  end
+
+  def organization
+    @organization ||= Organization.find_by(gh_id: @payload[:organization][:id])
+  end
+end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -251,7 +251,7 @@ Devise.setup do |config|
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
   config.omniauth :github, ENV.fetch('GH_APP_ID'), ENV.fetch('GH_APP_SECRET'),
-    scope: 'user,repo,admin:org'
+    scope: 'repo:status,admin:org,read:org,admin:repo_hook,admin:org_hook'
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or

--- a/db/migrate/20171220153058_remove_index_repositories_id_from_hooks.rb
+++ b/db/migrate/20171220153058_remove_index_repositories_id_from_hooks.rb
@@ -1,0 +1,5 @@
+class RemoveIndexRepositoriesIdFromHooks < ActiveRecord::Migration[5.1]
+  def change
+    remove_index :hooks, name: :index_hooks_on_repositories_id
+  end
+end

--- a/db/migrate/20171220153219_remove_repositories_id_from_hooks.rb
+++ b/db/migrate/20171220153219_remove_repositories_id_from_hooks.rb
@@ -1,0 +1,5 @@
+class RemoveRepositoriesIdFromHooks < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :hooks, :repositories_id, :bigint
+  end
+end

--- a/db/migrate/20171220153748_remove_repository_id_from_hooks.rb
+++ b/db/migrate/20171220153748_remove_repository_id_from_hooks.rb
@@ -1,0 +1,5 @@
+class RemoveRepositoryIdFromHooks < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :hooks, :repository_id, :integer
+  end
+end

--- a/db/migrate/20171220160037_replace_repo_type_with_hook_type_in_hooks.rb
+++ b/db/migrate/20171220160037_replace_repo_type_with_hook_type_in_hooks.rb
@@ -1,0 +1,5 @@
+class ReplaceRepoTypeWithHookTypeInHooks < ActiveRecord::Migration[5.1]
+  def change
+    rename_column :hooks, :repo_type, :hook_type
+  end
+end

--- a/db/migrate/20171220184700_add_resource_to_hooks.rb
+++ b/db/migrate/20171220184700_add_resource_to_hooks.rb
@@ -1,0 +1,5 @@
+class AddResourceToHooks < ActiveRecord::Migration[5.1]
+  def change
+    add_reference :hooks, :resource, polymorphic: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171219184811) do
+ActiveRecord::Schema.define(version: 20171220184700) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -62,17 +62,18 @@ ActiveRecord::Schema.define(version: 20171219184811) do
   end
 
   create_table "hooks", force: :cascade do |t|
-    t.string "repo_type"
+    t.string "hook_type"
     t.integer "gh_id"
     t.string "name"
     t.boolean "active"
     t.string "ping_url"
     t.string "test_url"
     t.integer "repository_id"
-    t.bigint "repositories_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["repositories_id"], name: "index_hooks_on_repositories_id"
+    t.string "resource_type"
+    t.bigint "resource_id"
+    t.index ["resource_type", "resource_id"], name: "index_hooks_on_resource_type_and_resource_id"
   end
 
   create_table "organizations", force: :cascade do |t|

--- a/spec/commands/process_webhook_event_spec.rb
+++ b/spec/commands/process_webhook_event_spec.rb
@@ -1,20 +1,17 @@
 require 'rails_helper'
 
 describe ProcessWebhookEvent do
-  def perform(*_args)
-    described_class.for(*_args)
+  def perform(request, event)
+    described_class.for(request: request, event: event)
   end
 
   context 'pull requests event' do
     let!(:event) { 'pull_request' }
     let!(:request) { {} }
 
-    before do
-      expect_any_instance_of(PullRequestService).to receive(:process).and_return(nil)
-    end
-
-    it 'call perform in pull request service' do
-      ProcessWebhookEvent.for(request: request, event: event)
+    it 'calls process on pull request service' do
+      expect_any_instance_of(PullRequestService).to receive(:process)
+      perform(request, event)
     end
   end
 
@@ -22,12 +19,19 @@ describe ProcessWebhookEvent do
     let!(:event) { 'pull_request_review' }
     let!(:request) { {} }
 
-    before do
-      expect_any_instance_of(PullRequestReviewService).to receive(:process).and_return(nil)
+    it 'calls process on pull request review service' do
+      expect_any_instance_of(PullRequestReviewService).to receive(:process)
+      perform(request, event)
     end
+  end
 
-    it 'call perform in pull request review service' do
-      ProcessWebhookEvent.for(request: request, event: event)
+  context 'pull request reviews event' do
+    let!(:event) { 'repository' }
+    let!(:request) { {} }
+
+    it 'calls process on pull request review service' do
+      expect_any_instance_of(RepositoryService).to receive(:process)
+      perform(request, event)
     end
   end
 end

--- a/spec/commands/untrack_spec.rb
+++ b/spec/commands/untrack_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe Untrack do
   let (:repository) { create(:repository) }
-  let!(:hook) { create(:hook, repository_id: repository.id, active: true) }
+  let!(:hook) { create(:hook, resource: repository, active: true) }
   let(:pull_request) { create(:pull_request, repository_id: repository.id) }
   let(:pull_request_relation) { create(pull_request_relation, pull_request_id: pull_request.id) }
 

--- a/spec/factories/hooks.rb
+++ b/spec/factories/hooks.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :hook do
-    repo_type ""
+    hook_type "Repository"
     gh_id 1
-    name "MyString"
+    name "web"
     active false
     ping_url "MyString"
     test_url "MyString"

--- a/spec/factories/organizations.rb
+++ b/spec/factories/organizations.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
     description "This is an organization's description"
     html_url "https://github.com/platanus"
     avatar_url "https://avatars3.githubusercontent.com/u/1158740?v=4"
+    tracked false
 
     association :owner, factory: :admin_user
   end

--- a/spec/models/hook_spec.rb
+++ b/spec/models/hook_spec.rb
@@ -3,6 +3,6 @@ require 'rails_helper'
 RSpec.describe Hook, type: :model do
   describe "validations" do
     it { should validate_presence_of :gh_id }
-    it { should validate_presence_of :repository_id }
+    it { should belong_to(:resource) }
   end
 end

--- a/spec/observers/hook_observer_spec.rb
+++ b/spec/observers/hook_observer_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe HookObserver do
   let(:organization) { create(:organization) }
   let(:repository) { create(:repository, organization_id: organization.id) }
-  let(:hook) { create(:hook, repository_id: repository.id) }
+  let(:hook) { create(:hook, resource: repository) }
 
   def trigger(type, event, object = hook)
     described_class.trigger(type, event, object)

--- a/spec/services/hook_service_spec.rb
+++ b/spec/services/hook_service_spec.rb
@@ -2,24 +2,14 @@ require 'rails_helper'
 
 describe HookService do
   let! (:admin_user) { build(:admin_user, token: 'a token') }
-  let (:repository) { create(:repository) }
+  let (:organization) { create(:organization, owner: admin_user) }
+  let (:repository) { create(:repository, organization: organization) }
   let (:client) { double }
-  let (:hook) { create(:hook, repository: repository, active: false) }
   let (:gh_conf) do
     {
       url: "#{ENV['APPLICATION_HOST']}/github_events",
       content_type: 'json',
       secret: ENV['GH_HOOK_SECRET']
-    }
-  end
-  let (:gh_response) do
-    {
-      type: "",
-      id: 1,
-      name: "",
-      active: true,
-      ping_url: "",
-      test_url: ""
     }
   end
 
@@ -29,50 +19,126 @@ describe HookService do
     allow(OctokitClient).to receive(:client).and_return(client)
   end
 
-  describe "#subscribe" do
-    def subscribe
-      subject.subscribe(repository)
+  describe 'org_hooks' do
+    let (:gh_response) do
+      {
+        type: 'Organization',
+        id: 1,
+        name: 'web',
+        active: true,
+        ping_url: 'https://api.github.com/orgs/octocat/hooks/1/pings',
+        test_url: 'https://api.github.com/orgs/octocat/hooks/1/tests'
+      }
     end
 
-    context "when the hook exist for this repository" do
+    describe "#subscribe" do
+      let (:hook) { create(:hook, resource: organization, active: false) }
+
+      def subscribe
+        subject.subscribe(organization)
+      end
+
+      context "when the hook exist for this organization" do
+        it "edits hook" do
+          expect(client).to receive(:edit_org_hook).with(
+            organization.login, hook.gh_id, gh_conf, active: true
+          )
+
+          expect { subscribe }.to change { hook.reload.active }.from(false).to true
+        end
+      end
+
+      context "when the hook doesn't exist for this organization" do
+        before do
+          expect(client).to receive(:create_org_hook).with(
+            organization.login, gh_conf,
+            events: ['repository'], active: true
+          ).and_return(gh_response)
+          HookService.new.subscribe(organization)
+          @hook = Hook.last
+        end
+
+        it { expect(@hook.active).to eq(true) }
+        it { expect(@hook.resource).to eq(organization) }
+      end
+    end
+
+    describe "#unsubscribe" do
+      let (:hook) { create(:hook, resource: organization, active: true) }
+
+      def unsubscribe
+        subject.unsubscribe(organization)
+      end
+
       before do
-        expect(client).to receive(:edit_hook).with(
-          repository.full_name, hook.gh_id, 'web', gh_conf, active: true
+        expect(client).to receive(:edit_org_hook).with(
+          organization.login, hook.gh_id, gh_conf, active: false
         )
       end
 
-      it { expect { subscribe }.to change { hook.reload.active }.from(false).to true }
-    end
-
-    context "when the hook doesn't exist for this repository" do
-      before do
-        expect(client).to receive(:create_hook).with(
-          repository.full_name, 'web', gh_conf,
-          events: ['pull_request', 'pull_request_review'], active: true
-        ).and_return(gh_response)
-        HookService.new.subscribe(repository)
-        @hook = Hook.last
-      end
-
-      it { expect(@hook.active).to eq(true) }
-      it { expect(@hook.repository).to eq(repository) }
+      it { expect { unsubscribe }.to change { hook.reload.active }.from(true).to false }
     end
   end
 
-  describe "#unsubscribe" do
-    let (:hook) { create(:hook, repository: repository, active: true) }
-
-    def unsubscribe
-      subject.unsubscribe(repository)
+  describe 'repo_hooks' do
+    let (:gh_response) do
+      {
+        type: 'Repository',
+        id: 1,
+        name: 'web',
+        active: true,
+        ping_url: 'https://api.github.com/repos/octocat/Hello-World/hooks/1/pings',
+        test_url: 'https://api.github.com/repos/octocat/Hello-World/hooks/1/tests'
+      }
     end
 
-    before do
-      expect(client).to receive(:edit_hook).with(
-        repository.full_name, hook.gh_id, 'web', gh_conf, active: false
-      )
+    describe "#subscribe" do
+      let (:hook) { create(:hook, resource: repository, active: false) }
+
+      def subscribe
+        subject.subscribe(repository)
+      end
+
+      context "when the hook exist for this repository" do
+        it "edits hook" do
+          expect(client).to receive(:edit_hook).with(
+            repository.full_name, hook.gh_id, 'web', gh_conf, active: true
+          )
+
+          expect { subscribe }.to change { hook.reload.active }.from(false).to true
+        end
+      end
+
+      context "when the hook doesn't exist for this repository" do
+        before do
+          expect(client).to receive(:create_hook).with(
+            repository.full_name, 'web', gh_conf,
+            events: ['pull_request', 'pull_request_review'], active: true
+          ).and_return(gh_response)
+          HookService.new.subscribe(repository)
+          @hook = Hook.last
+        end
+
+        it { expect(@hook.active).to eq(true) }
+        it { expect(@hook.resource).to eq(repository) }
+      end
     end
 
-    it { expect { unsubscribe }.to change { hook.reload.active }.from(true).to false }
+    describe "#unsubscribe" do
+      let (:hook) { create(:hook, resource: repository, active: true) }
+
+      def unsubscribe
+        subject.unsubscribe(repository)
+      end
+
+      before do
+        expect(client).to receive(:edit_hook).with(
+          repository.full_name, hook.gh_id, 'web', gh_conf, active: false
+        )
+      end
+
+      it { expect { unsubscribe }.to change { hook.reload.active }.from(true).to false }
+    end
   end
 
   describe "#destroy_api_hook" do

--- a/spec/services/repository_service_spec.rb
+++ b/spec/services/repository_service_spec.rb
@@ -1,0 +1,74 @@
+require 'rails_helper'
+
+describe RepositoryService do
+  let(:organization) { create(:organization, gh_id: 7649605) }
+  let(:partial_payload) do
+    {
+      repository: {
+        id: 27496774,
+        name: 'new-repository',
+        full_name: 'baxterandthehackers/new-repository',
+        url: 'https://api.github.com/repos/baxterandthehackers/new-repository',
+        html_url: 'https://github.com/baxterandthehackers/new-repository'
+      },
+      organization: {
+        id: organization.gh_id
+      }
+    }
+  end
+
+  def build(payload)
+    described_class.new(payload: payload)
+  end
+
+  context "on create" do
+    let(:payload) { { **partial_payload, action: 'created' } }
+
+    it "calls create_repository" do
+      expect_any_instance_of(described_class).to(
+        receive(:create_repository)
+      )
+      build(payload).process
+    end
+
+    it "creates repo" do
+      build(payload).process
+      expect(
+        Repository.where(
+          gh_id: payload[:repository][:id],
+          name: payload[:repository][:name],
+          full_name: payload[:repository][:full_name],
+          tracked: false,
+          url: payload[:repository][:url],
+          html_url: payload[:repository][:html_url]
+        )
+      ).to exist
+    end
+  end
+
+  context "on delete" do
+    let(:payload) { { **partial_payload, action: 'deleted' } }
+
+    it "calls create_repository" do
+      expect_any_instance_of(described_class).to(
+        receive(:delete_repository)
+      )
+      build(payload).process
+    end
+
+    it "destroys repo" do
+      build(payload).process
+
+      expect(
+        Repository.where(
+          gh_id: payload[:repository][:id],
+          name: payload[:repository][:name],
+          full_name: payload[:repository][:full_name],
+          tracked: false,
+          url: payload[:repository][:url],
+          html_url: payload[:repository][:html_url]
+        )
+      ).not_to exist
+    end
+  end
+end


### PR DESCRIPTION
Extends hooks to create Organization hooks, that listen to repositories creation and deletion. These hooks are created when an Organization is tracked.